### PR TITLE
Fix macos build and rendering issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,8 @@ dependencies {
     compile "org.openjfx:javafx-graphics:11:${platform}"
     compile "org.openjfx:javafx-controls:11:${platform}"
     compile "org.openjfx:javafx-fxml:11:${platform}"
+    compile "org.openjfx:javafx-media:11:${platform}"
+    compile "org.openjfx:javafx-web:11:${platform}"
     compile 'javax.annotation:javax.annotation-api:1.3.2'
 
     compile 'eu.lestard:advanced-bindings:0.4.0'

--- a/griffon-app/views/org/laeq/editor/ControlsView.java
+++ b/griffon-app/views/org/laeq/editor/ControlsView.java
@@ -186,6 +186,7 @@ public class ControlsView extends AbstractJavaFXGriffonView {
     private Scene init() {
         Scene scene = new Scene(new Group());
         scene.setFill(Color.WHITE);
+        scene.getStylesheets().add("org/kordamp/bootstrapfx/bootstrapfx.css");
 
         Node node = loadFromFXML();
         if (node instanceof Parent) {


### PR DESCRIPTION
While trying to build and run Vifeco on Mac OS, I ran across a couple of issues fixed here:
* dependencies `javafx-media` and `javafx-web` were missing, causing builds to fail
* the controls view had unreadable characters, which seemed to come from a fonts rendering issue -> loading a CSS stylesheet, as done in other views, fixes it.

Happy to discuss in case I have missed something :)