### PR TITLE
Provide finer granularity for icon duration controls

### DIFF
--- a/griffon-app/i18n/messages.properties
+++ b/griffon-app/i18n/messages.properties
@@ -144,3 +144,5 @@ z.javaVersion = Java version
 z.fxVersion = JavaFX version
 z.latest_release = Latest release
 z.volume = volume
+z.over1s = over 1s
+z.under1s = under 1s

--- a/griffon-app/i18n/messages_es.properties
+++ b/griffon-app/i18n/messages_es.properties
@@ -154,3 +154,5 @@ z.javaVersion = Versión de Java
 z.fxVersion = versión de JavaFX
 z.latest_release = Última versión
 z.volume = Volumen
+z.over1s = menos de 1s
+z.under1s = más de 1s

--- a/griffon-app/i18n/messages_fr.properties
+++ b/griffon-app/i18n/messages_fr.properties
@@ -144,3 +144,5 @@ z.javaVersion = Version Java
 z.fxVerxion = version JavaFX
 z.latest_release = Dernière version
 z.volume = volume
+z.over1s = moins de 1s
+z.under1s = plus de 1s

--- a/griffon-app/models/org/laeq/editor/Controls.java
+++ b/griffon-app/models/org/laeq/editor/Controls.java
@@ -7,7 +7,7 @@ public final class Controls {
     public final Double[] speedValue = new Double[]{0.1d, 10.0};
     public final Double[] opacityValue = new Double[]{.1, 1.0};
     public final Double[] sizeValue = new Double[]{10d, 80d};
-    public final Double[] durationValue = new Double[]{0.1d, 30d};
+    public final Double[] durationValue = new Double[]{1d, 30d};
     public final Double[] volumeValue = new Double[]{0d, 1.0};
 
     public final SimpleDoubleProperty duration = new SimpleDoubleProperty(3);

--- a/griffon-app/models/org/laeq/editor/Controls.java
+++ b/griffon-app/models/org/laeq/editor/Controls.java
@@ -7,7 +7,7 @@ public final class Controls {
     public final Double[] speedValue = new Double[]{0.1d, 10.0};
     public final Double[] opacityValue = new Double[]{.1, 1.0};
     public final Double[] sizeValue = new Double[]{10d, 80d};
-    public final Double[] durationValue = new Double[]{1d, 30d};
+    public final Double[] durationValue = new Double[]{0.1d, 30d};
     public final Double[] volumeValue = new Double[]{0d, 1.0};
 
     public final SimpleDoubleProperty duration = new SimpleDoubleProperty(3);

--- a/griffon-app/resources/org/laeq/editor/controls.fxml
+++ b/griffon-app/resources/org/laeq/editor/controls.fxml
@@ -11,6 +11,11 @@
       <Slider fx:id="size" layoutX="10.0" layoutY="95.0" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="50.0" AnchorPane.topAnchor="95.0" />
       <Label layoutX="10.0" layoutY="133.0" prefHeight="17.0" prefWidth="173.0" AnchorPane.leftAnchor="10.0" AnchorPane.topAnchor="133.0" JavaFXUtils.i18nKey="z.duration" />
       <Slider fx:id="duration" layoutX="10.0" layoutY="158.0" AnchorPane.leftAnchor="10.0" AnchorPane.rightAnchor="50.0" AnchorPane.topAnchor="158.0" />
+      <fx:define>
+          <ToggleGroup fx:id="durationInterval"/>
+      </fx:define>
+      <RadioButton fx:id="durationUnder1s" layoutX="100.0" layoutY="133.0" AnchorPane.rightAnchor="170.0" AnchorPane.topAnchor="133.0" toggleGroup="$durationInterval" JavaFXUtils.i18nKey="z.under1s"/>
+      <RadioButton fx:id="durationOver1s" layoutX="200.0" layoutY="133.0" AnchorPane.rightAnchor="50.0" AnchorPane.topAnchor="133.0" toggleGroup="$durationInterval" JavaFXUtils.i18nKey="z.over1s"/>
       <Label fx:id="speedLabel" layoutX="158.0" layoutY="28.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="30.0" />
       <Label fx:id="sizeLabel" layoutX="162.0" layoutY="95.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="90.0" />
       <Label fx:id="durationLabel" layoutX="162.0" layoutY="158.0" AnchorPane.rightAnchor="10.0" AnchorPane.topAnchor="155.0" />

--- a/griffon-app/views/org/laeq/editor/ControlsView.java
+++ b/griffon-app/views/org/laeq/editor/ControlsView.java
@@ -91,7 +91,7 @@ public class ControlsView extends AbstractJavaFXGriffonView {
     }
 
     private void initDurationSlider() {
-        durationLabel.setText(String.format("%.0f s", controls.duration.getValue()));
+        durationLabel.setText(String.format("%.2f s", controls.duration.getValue()));
         duration.valueProperty().bindBidirectional(controls.duration);
         duration.setMin(controls.durationValue[0]);
         duration.setMax(controls.durationValue[1]);
@@ -99,9 +99,9 @@ public class ControlsView extends AbstractJavaFXGriffonView {
         duration.setShowTickMarks(true);
         duration.setShowTickLabels(true);
         duration.valueProperty().addListener((obs, oldval, newVal) -> {
-            double value = Math.round(newVal.doubleValue() * 1) / 1f;
+            double value = newVal.doubleValue();
             duration.setValue(value);
-            durationLabel.setText(String.format("%.0f s", value));
+            durationLabel.setText(String.format("%.2f s", value));
             controller.dispatch("duration.change", Double.valueOf(value));
             controls.duration.set(value);
         });

--- a/griffon-app/views/org/laeq/editor/ControlsView.java
+++ b/griffon-app/views/org/laeq/editor/ControlsView.java
@@ -4,12 +4,14 @@ import griffon.core.artifact.GriffonView;
 import griffon.core.mvc.MVCGroup;
 import griffon.inject.MVCMember;
 import griffon.metadata.ArtifactProviderFor;
+import javafx.beans.value.ObservableValue;
 import javafx.fxml.FXML;
 import javafx.scene.Group;
 import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
+import javafx.scene.control.RadioButton;
 import javafx.scene.control.Slider;
 import javafx.scene.image.Image;
 import javafx.scene.paint.Color;
@@ -39,6 +41,9 @@ public class ControlsView extends AbstractJavaFXGriffonView {
     @FXML private Label sizeLabel;
     @FXML private Label volumeLabel;
 
+    @FXML private RadioButton durationUnder1s;
+    @FXML private RadioButton durationOver1s;
+
     @MVCMember
     public void setController(@Nonnull ControlsController controller) {
         this.controller = controller;
@@ -67,7 +72,20 @@ public class ControlsView extends AbstractJavaFXGriffonView {
         });
 
         initSpeedSlider();
-        initDurationSlider();
+
+        durationUnder1s.setOnAction(action -> {
+            initDurationSlider(0.01d, 1d, 0.1d);
+        });
+        durationOver1s.selectedProperty().addListener(
+            (ObservableValue<? extends Boolean> ov, Boolean old_val, Boolean new_val) ->{
+            initDurationSlider(
+                    controls.durationValue[0],
+                    controls.durationValue[1],
+                    5);
+        });
+
+        durationOver1s.setSelected(true);
+
         initSizeSlider();
         initOpacitySlider();
         initVolumeSlider();
@@ -90,12 +108,12 @@ public class ControlsView extends AbstractJavaFXGriffonView {
         });
     }
 
-    private void initDurationSlider() {
+    private void initDurationSlider(double min, double max, double tickUnit) {
         durationLabel.setText(String.format("%.2f s", controls.duration.getValue()));
         duration.valueProperty().bindBidirectional(controls.duration);
-        duration.setMin(controls.durationValue[0]);
-        duration.setMax(controls.durationValue[1]);
-        duration.setMajorTickUnit(5);
+        duration.setMin(min);
+        duration.setMax(max);
+        duration.setMajorTickUnit(tickUnit);
         duration.setShowTickMarks(true);
         duration.setShowTickLabels(true);
         duration.valueProperty().addListener((obs, oldval, newVal) -> {


### PR DESCRIPTION
Icon duration can be set with finer granularity, including durations under 1s.
Since providing the whole range from <1 to 30s with lower increments on a single slider did not look very useable to me, this can now be done by selecting which interval to use (<1s or the usual [1,30]s):
* default view, when opening the `Controls` dialog:
![vifeco_default](https://user-images.githubusercontent.com/2477066/174446551-4ddb0d7c-fa52-4157-8b4a-a67659831bce.png)

* default view when selecting `under 1s` as interval:
![vifeco_under_1s](https://user-images.githubusercontent.com/2477066/174446553-d03dfac2-1148-4bb4-8fe4-bb55d28f9dc3.png)

* example of a selected duration under 1s:
![vifeco_under_1s_custom_value](https://user-images.githubusercontent.com/2477066/174446556-58dee5b3-6cc3-4fee-966b-562021b3d50b.png)


Closes #36.